### PR TITLE
Extend image properties with an operating system description.

### DIFF
--- a/specifications/providers/openstack/flavors_and_images.md
+++ b/specifications/providers/openstack/flavors_and_images.md
@@ -126,6 +126,10 @@ As defined by this specification we expect:
 ```json
 {
   "properties": {
+    "unikorn:os_name": "Ubuntu",
+    "unikorn:os_version": "24.04",
+    "unikorn:os_family": "Debian",
+    "unikorn:tags": "slurmd=24.11,wireguard=1.0",
     "unikorn:gpu_vendor": "AMD",
     "unikorn:gpu_models": "MI250X,MI300X",
     "unikorn:gpu_driver_version": "v1.2.3",
@@ -135,6 +139,10 @@ As defined by this specification we expect:
   }
 }
 ```
+
+The Image OS fields (name, version and family) describes the operating system in use. `os_name`, `os_version` and `os_family` defines the full name, version and family of the operating system.
+
+The `tags` field is particularly helpfull for filtering images based on the software stack they contain. It can be used to easily identify images with specific tools or configuration.
 
 The GPU fields are optional, the existence of `gpu_vendor` defines this as compatible with a GPU flavor, and the `gpu_models` and `gpu_driver_version` are required.
 The `gpu_models` is formatted as a CSV, and must correspond exactly to values defined by flavor mapping.

--- a/specifications/providers/openstack/flavors_and_images.md
+++ b/specifications/providers/openstack/flavors_and_images.md
@@ -13,6 +13,10 @@ While this problem applies to CPUs too, that's readily supported by OpenStack fo
 
 - v1.0.0 2024-06-26 (@spjmurray): Initial RFC
 - v1.0.1 2024-07-23 (@spjmurray): Updated metadata values
+- v2.0.0 2024-12-04 (@nsricardor):
+  - **Added** new image metadata properties to describe the operating system: `unikorn:os:*` 
+  - **Added** new image metadata property to list packages availables on the image: `unikorn:package:*`
+  - **Removed** the image property `unikorn:kubernetes_version`, now replaced by `unikorn:package:kubernetes`
 
 ## Applying Images to Hardware
 
@@ -132,11 +136,11 @@ As defined by this specification we expect:
     "unikorn:os:variant": "server",
     "unikorn:os:codename": "Noble Numbat",
     "unikorn:os:version": "24.04",
-    "unikorn:packages": "slurmd=24.11,wireguard=1.0",
+    "unikorn:package:kubernetes": "x.y.z",
+    "unikorn:package:slurmd": "x.y.z",
     "unikorn:gpu_vendor": "AMD",
     "unikorn:gpu_models": "MI250X,MI300X",
     "unikorn:gpu_driver_version": "v1.2.3",
-    "unikorn:kubernetes_version": "v1.2.3",
     "unikorn:virtualization": "any",
     "unikorn:digest": "ZnViYXI="
   }
@@ -155,12 +159,10 @@ As defined by this specification we expect:
 
 `unikorn:os:version`specifies the version of the operating system (e.g., 24.04, 20.04).
 
-`unikorn:packages` is an optional list of installed packages, particularly helpful for filtering images based on the software stack they contain.
+`unikorn:package:*` is an optional list of installed packages, particularly helpful for filtering images based on the software stack they contain (e.g. unikorn:package:kubernetes: x.y.z). 
 
 The GPU fields are optional, the existence of `gpu_vendor` defines this as compatible with a GPU flavor, and the `gpu_models` and `gpu_driver_version` are required.
 The `gpu_models` is formatted as a CSV, and must correspond exactly to values defined by flavor mapping.
-
-The Kubernetes fields are optional and only defined when intended to be used for deployment of Kubernetes services.
 
 The virtualization fields define where the image can be used, `any` means it can be used anywhere, `baremetal` and `virtualized` indicate it can be only used on flavors that match that usage.
 

--- a/specifications/providers/openstack/flavors_and_images.md
+++ b/specifications/providers/openstack/flavors_and_images.md
@@ -126,10 +126,13 @@ As defined by this specification we expect:
 ```json
 {
   "properties": {
-    "unikorn:os_name": "Ubuntu",
-    "unikorn:os_version": "24.04",
-    "unikorn:os_family": "Debian",
-    "unikorn:tags": "slurmd=24.11,wireguard=1.0",
+    "unikorn:os:kernel": "linux",
+    "unikorn:os:familiy": "debian",
+    "unikorn:os:distro": "ubuntu",
+    "unikorn:os:variant": "server",
+    "unikorn:os:codename": "Noble Numbat",
+    "unikorn:os:version": "24.04",
+    "unikorn:packages": "slurmd=24.11,wireguard=1.0",
     "unikorn:gpu_vendor": "AMD",
     "unikorn:gpu_models": "MI250X,MI300X",
     "unikorn:gpu_driver_version": "v1.2.3",
@@ -140,9 +143,19 @@ As defined by this specification we expect:
 }
 ```
 
-The Image OS fields (name, version and family) describes the operating system in use. `os_name`, `os_version` and `os_family` defines the full name, version and family of the operating system.
+`unikorn:os:kernel` specifies the kernel used by the operating system (e.g., linux, windows).
 
-The `tags` field is particularly helpfull for filtering images based on the software stack they contain. It can be used to easily identify images with specific tools or configuration.
+`unikorn:os:familiy` defines the operating system family, which typically determines the package format (e.g., debian, redhat).
+
+`unikorn:os:distro` indicates the specific operating system distribution (e.g., ubuntu, centos).
+
+`unikorn:os:variant` is an optional field and define the variant or edition of the operating system, such as "server" or "desktop".
+
+`unikorn:os:codename` is an optional field and refers to the codename for the operating system release (e.g., Noble Numbat).
+
+`unikorn:os:version`specifies the version of the operating system (e.g., 24.04, 20.04).
+
+`unikorn:packages` is an optional list of installed packages, particularly helpful for filtering images based on the software stack they contain.
 
 The GPU fields are optional, the existence of `gpu_vendor` defines this as compatible with a GPU flavor, and the `gpu_models` and `gpu_driver_version` are required.
 The `gpu_models` is formatted as a CSV, and must correspond exactly to values defined by flavor mapping.

--- a/specifications/providers/openstack/flavors_and_images.md
+++ b/specifications/providers/openstack/flavors_and_images.md
@@ -157,7 +157,7 @@ As defined by this specification we expect:
 
 `unikorn:os:codename` is an optional field and refers to the codename for the operating system release (e.g., Noble Numbat).
 
-`unikorn:os:version`specifies the version of the operating system (e.g., 24.04, 20.04).
+`unikorn:os:version` specifies the version of the operating system (e.g., 24.04, 20.04).
 
 `unikorn:package:*` is an optional list of installed packages, particularly helpful for filtering images based on the software stack they contain. The key, prefixed with `unikorn:package:` represents the package name, and the value specifies its version semver format (e.g. unikorn:package:kubernetes: v1.2.3). 
 

--- a/specifications/providers/openstack/flavors_and_images.md
+++ b/specifications/providers/openstack/flavors_and_images.md
@@ -136,8 +136,8 @@ As defined by this specification we expect:
     "unikorn:os:variant": "server",
     "unikorn:os:codename": "Noble Numbat",
     "unikorn:os:version": "24.04",
-    "unikorn:package:kubernetes": "x.y.z",
-    "unikorn:package:slurmd": "x.y.z",
+    "unikorn:package:kubernetes": "v1.2.3",
+    "unikorn:package:slurmd": "v1.2.3",
     "unikorn:gpu_vendor": "AMD",
     "unikorn:gpu_models": "MI250X,MI300X",
     "unikorn:gpu_driver_version": "v1.2.3",
@@ -159,7 +159,7 @@ As defined by this specification we expect:
 
 `unikorn:os:version`specifies the version of the operating system (e.g., 24.04, 20.04).
 
-`unikorn:package:*` is an optional list of installed packages, particularly helpful for filtering images based on the software stack they contain (e.g. unikorn:package:kubernetes: x.y.z). 
+`unikorn:package:*` is an optional list of installed packages, particularly helpful for filtering images based on the software stack they contain. The key, prefixed with `unikorn:package:` represents the package name, and the value specifies its version semver format (e.g. unikorn:package:kubernetes: v1.2.3). 
 
 The GPU fields are optional, the existence of `gpu_vendor` defines this as compatible with a GPU flavor, and the `gpu_models` and `gpu_driver_version` are required.
 The `gpu_models` is formatted as a CSV, and must correspond exactly to values defined by flavor mapping.
@@ -200,3 +200,23 @@ This allows, for example, vendor logos to be displayed in UI components.
 | A100 | NVIDIA A100 Tensor Core |
 | H100 | NVIDIA H100 Tensor Core |
 | H200 | NVIDIA H200 Tensor Core |
+
+### OS Kernel
+
+| Value | Description |
+| --- | --- |
+| linux | Linux |
+
+### OS Family
+
+| Value | Description |
+| --- | --- |
+| debian | Debian |
+| redhat | Redhat |
+
+### OS Distro
+
+| Value | Description |
+| --- | --- |
+| rocky | Rocky |
+| ubuntu | Ubuntu |


### PR DESCRIPTION
Extend the OpenStack image specification so the region service can use the properties to provide an operating system description.